### PR TITLE
Fixed getIdentifier() must be of the type string

### DIFF
--- a/src/ParamConverter/HashidsParamConverter.php
+++ b/src/ParamConverter/HashidsParamConverter.php
@@ -45,7 +45,7 @@ class HashidsParamConverter implements ParamConverterInterface
             $this->getIdentifier(
                 $request,
                 array_replace(['hashid' => null], $configuration->getOptions()),
-                $configuration->getName()
+                (string) $configuration->getName()
             )
         );
 


### PR DESCRIPTION
When `$configuration->getName()` is `null`, which is possible with the default `@ParamConverter` from `FrameworkExtraBundle` an exception will be thrown because `getIdentifier` requires a string as third param. 
Using `?string $name` is not allowed since the bundle should be compatible with php >= 7.1

`private function getIdentifier(Request $request, $options, string $name): string`